### PR TITLE
Validate loan request dates

### DIFF
--- a/app/models/loan_request.rb
+++ b/app/models/loan_request.rb
@@ -1,15 +1,17 @@
 class LoanRequest < ActiveRecord::Base
   belongs_to :user
   default_scope { order('updated_at DESC') }
+  scope :status, -> (status) { where status: status }
 
   has_many :loan_request_categories
   has_many :categories, through: :loan_request_categories
   has_many :loans
-  has_attached_file :image, styles: {
-    thumb: '100x100>',
-    main: '300x300>'
-  }, default_url: 'missing.png'
+  has_attached_file :image, styles: { thumb: '100x100>', main: '300x300>' },
+                            default_url: 'missing.png'
 
+  validate :request_date
+  validate :begin_date
+  validate :end_date
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
   validates :user_id, presence: true
   validates :title, presence: true
@@ -22,7 +24,25 @@ class LoanRequest < ActiveRecord::Base
   validates :payments_end_date, presence: true
   validates :status, presence: true
 
-  scope :status, -> (status) { where status: status }
+  def request_date
+    if requested_by_date.present? && requested_by_date < Date.today
+      errors.add(:requested_by_date, 'cannot be in the past')
+    end
+  end
+
+  def begin_date
+    if payments_begin_date.present? &&
+       payments_begin_date < requested_by_date.months_since(1)
+      errors.add(:payments_begin_date, 'must be at least one month from today')
+    end
+  end
+
+  def end_date
+    if payments_end_date.present? &&
+       payments_end_date < requested_by_date.months_since(3)
+      errors.add(:payments_end_date, 'must be at least three months from today')
+    end
+  end
 
   def loan_term
     ((payments_end_date - payments_begin_date) / 2_592_000).round

--- a/app/models/loan_request.rb
+++ b/app/models/loan_request.rb
@@ -17,7 +17,8 @@ class LoanRequest < ActiveRecord::Base
   validates :title, presence: true
   validates :blurb, presence: true
   validates :description, presence: true
-  validates :borrowing_amount, presence: true
+  validates :borrowing_amount, presence: true,
+                               numericality: { only_integer: true }
   validates :amount_funded, presence: true
   validates :requested_by_date, presence: true
   validates :payments_begin_date, presence: true

--- a/spec/features/cart_spec.rb
+++ b/spec/features/cart_spec.rb
@@ -1,89 +1,81 @@
-require "rails_helper"
+require 'rails_helper'
 
 describe 'Cart' do
   before(:each) do
-    LoanRequest.create!(user:                user,
-                        title:               "Buy Jorge Beiber Tickets",
-                        blurb:               "Jorge loves Bieber",
-                        description:         "Jorge desperately wants to see a concert!",
-                        borrowing_amount:    500,
-                        amount_funded:       10,
-                        requested_by_date:   DateTime.new(2015, 3, 25),
-                        payments_begin_date: DateTime.new(2015, 7, 25),
-                        payments_end_date:   DateTime.new(2015, 10, 25),
-                        status:              "open"
-                       )
+    LoanRequest.create!(user: user,
+                        title: 'Buy Jorge Beiber Tickets',
+                        blurb: 'Jorge loves Bieber',
+                        description: 'Jorge desperately wants to see a concert!',
+                        borrowing_amount: 500,
+                        amount_funded: 10,
+                        requested_by_date: DateTime.now,
+                        payments_begin_date: DateTime.now.months_since(1),
+                        payments_end_date: DateTime.now.months_since(7),
+                        status: 'open')
 
-    LoanRequest.create!(user:               user,
-                        title:               "Steve needs a new phone.",
-                        blurb:               "Steve is clumsy.",
-                        description:         "Steve broke his phone and it doesn't work.",
-                        borrowing_amount:    800,
-                        amount_funded:       60,
-                        requested_by_date:   DateTime.new(2014, 12, 28),
-                        payments_begin_date: DateTime.new(2015, 3, 30),
-                        payments_end_date:   DateTime.new(2015, 8, 17),
-                        status:              "open"
-                       )
+    LoanRequest.create!(user: user,
+                        title: 'Steve needs a new phone.',
+                        blurb: 'Steve is clumsy.',
+                        description: "Steve broke his phone and it doesn't work.",
+                        borrowing_amount: 800,
+                        amount_funded: 60,
+                        requested_by_date: DateTime.now,
+                        payments_begin_date: DateTime.now.months_since(1),
+                        payments_end_date: DateTime.now.months_since(7),
+                        status: 'open')
 
     tenant.users << user
-    visit "/loan_requests"
+    visit '/loan_requests'
   end
 
   let(:user) do
-    User.create!(first_name: "tom",
-                 email:      "example@example.com",
-                 username:   "tom foolery",
-                 password:   "password"
-                )
+    User.create!(first_name: 'tom',
+                 email:      'example@example.com',
+                 username:   'tom foolery',
+                 password:   'password')
   end
 
   let(:tenant) do
-    Tenant.create!(name: "Fantastico")
+    Tenant.create!(name: 'Fantastico')
   end
 
   it "can't visit the cart page without items in the cart" do
-    visit "/cart"
-    expect(page).to have_content("cart is empty")
+    visit '/cart'
+    expect(page).to have_content('cart is empty')
   end
 
-  context "adding items to the cart" do
-    it "has items on the page" do
-      expect(page).to have_content("Buy Jorge Beiber Tickets")
+  context 'adding items to the cart' do
+    it 'has items on the page' do
+      expect(page).to have_content('Buy Jorge Beiber Tickets')
     end
 
-    it "can add items and they persist after logging in" do
+    it 'can add items and they persist after logging in' do
       find(:css, "#loan_requests_[value='#{LoanRequest.first.id}']").set(true)
       find('input[value="Add selected Loans to Cart"]').click
-      expect(current_path).to eq("/cart")
-      expect(page).to have_content("Your Cart")
-      expect(page).to have_content("Steve Needs A New Phone.")
+      expect(current_path).to eq('/cart')
+      expect(page).to have_content('Your Cart')
+      expect(page).to have_content('Steve Needs A New Phone.')
 
-      fill_in "username", with: user.username
-      fill_in "password", with: user.password
+      fill_in 'username', with: user.username
+      fill_in 'password', with: user.password
       find('input[value="Log In"]').click
 
-      visit "/cart"
-      expect(page).to have_content("Steve Needs A New Phone.")
+      visit '/cart'
+      expect(page).to have_content('Steve Needs A New Phone.')
     end
 
-    it "can add items from multiple borrowers" do
+    it 'can add items from multiple borrowers' do
       find(:css, "#loan_requests_[value='#{LoanRequest.first.id}']").set(true)
       find(:css, "#loan_requests_[value='#{LoanRequest.second.id}']").set(true)
       find('input[value="Add selected Loans to Cart"]').click
 
-      expect(page).to have_content("Steve Needs A New Phone.")
-      expect(page).to have_content("Buy Jorge Beiber Tickets")
+      expect(page).to have_content('Steve Needs A New Phone.')
+      expect(page).to have_content('Buy Jorge Beiber Tickets')
     end
   end
 
-  context "checkout process" do
-    it "has a checkout button" do
-
+  context 'checkout process' do
+    it 'has a checkout button' do
     end
-
   end
-
-
-
 end

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -1,83 +1,83 @@
-require "rails_helper"
+require 'rails_helper'
 
-describe "checkout" do
-  context "checkout process" do
-    it "can go through a whole process" do
+describe 'checkout' do
+  context 'checkout process' do
+    it 'can go through a whole process' do
       visit root_path
-      click_link_or_button "Sign Up"
+      click_link_or_button 'Sign Up'
       expect(page).to have_content('Register as a Keevahh User')
-      fill_in 'user[first_name]', with: "Chase"
-      fill_in 'user[last_name]', with: "van Hekken"
-      fill_in 'user[email]', with: "chase@gmail.com"
-      fill_in 'user[username]', with: "ChasevH"
-      fill_in 'user[password]', with: "password"
-      fill_in 'user[password_confirmation]', with: "password"
+      fill_in 'user[first_name]', with: 'Chase'
+      fill_in 'user[last_name]', with: 'van Hekken'
+      fill_in 'user[email]', with: 'chase@gmail.com'
+      fill_in 'user[username]', with: 'ChasevH'
+      fill_in 'user[password]', with: 'password'
+      fill_in 'user[password_confirmation]', with: 'password'
       click_button 'Submit'
 
       find(:xpath, "//a/img[@alt='Borrow']/..").click
-      expect(page).to have_content("Apply to Become a Borrower!")
+      expect(page).to have_content('Apply to Become a Borrower!')
 
-      fill_in 'tenant[name]', with: "Chase Business"
-      fill_in 'tenant[description]', with: "This good description"
+      fill_in 'tenant[name]', with: 'Chase Business'
+      fill_in 'tenant[description]', with: 'This good description'
       click_link_or_button 'Apply'
-      expect(page).to have_content("Chase Business")
-      click_link_or_button "Create new loan request"
-      expect(page).to have_content("Create New Loan Request")
+      expect(page).to have_content('Chase Business')
+      click_link_or_button 'Create new loan request'
+      expect(page).to have_content('Create New Loan Request')
 
-      fill_in 'loan_request[title]', with: "I need money"
-      fill_in 'loan_request[blurb]', with: "I need more money"
-      fill_in 'loan_request[description]', with: "I need lots of  money"
-      fill_in 'loan_request[borrowing_amount]', with: "5000"
-      fill_in 'loan_request[requested_by_date]', with: DateTime.new(2015, 01, 01)
-      fill_in 'loan_request[payments_begin_date]', with: DateTime.new(2015, 01, 28)
-      fill_in 'loan_request[payments_end_date]', with: DateTime.new(2015, 12, 28)
-      click_link_or_button "Submit"
+      fill_in 'loan_request[title]', with: 'I need money'
+      fill_in 'loan_request[blurb]', with: 'I need more money'
+      fill_in 'loan_request[description]', with: 'I need lots of  money'
+      fill_in 'loan_request[borrowing_amount]', with: '5000'
+      fill_in 'loan_request[requested_by_date]', with: DateTime.now
+      fill_in 'loan_request[payments_begin_date]', with: DateTime.now.months_since(1)
+      fill_in 'loan_request[payments_end_date]', with: DateTime.now.months_since(10)
+      click_link_or_button 'Submit'
 
-      within("nav") do
-        click_link_or_button "Make A Loan"
+      within('nav') do
+        click_link_or_button 'Make A Loan'
       end
-      expect(page).to have_content("Loan Requests")
+      expect(page).to have_content('Loan Requests')
 
       find("input[type='checkbox']").set(true)
 
-      click_link_or_button("Add selected Loans to Cart")
+      click_link_or_button('Add selected Loans to Cart')
 
-      click_link_or_button("Checkout")
+      click_link_or_button('Checkout')
 
-      expect(page).to have_content("Amount You Funded This Order: $25")
+      expect(page).to have_content('Amount You Funded This Order: $25')
     end
 
     it "can't make loan request without title" do
       visit root_path
-      click_link_or_button "Sign Up"
+      click_link_or_button 'Sign Up'
       expect(page).to have_content('Register as a Keevahh User')
-      fill_in 'user[first_name]', with: "Chase"
-      fill_in 'user[last_name]', with: "van Hekken"
-      fill_in 'user[email]', with: "chase@gmail.com"
-      fill_in 'user[username]', with: "ChasevH"
-      fill_in 'user[password]', with: "password"
-      fill_in 'user[password_confirmation]', with: "password"
+      fill_in 'user[first_name]', with: 'Chase'
+      fill_in 'user[last_name]', with: 'van Hekken'
+      fill_in 'user[email]', with: 'chase@gmail.com'
+      fill_in 'user[username]', with: 'ChasevH'
+      fill_in 'user[password]', with: 'password'
+      fill_in 'user[password_confirmation]', with: 'password'
       click_button 'Submit'
 
       find(:xpath, "//a/img[@alt='Borrow']/..").click
-      expect(page).to have_content("Apply to Become a Borrower!")
+      expect(page).to have_content('Apply to Become a Borrower!')
 
-      fill_in 'tenant[name]', with: "Chase Business"
-      fill_in 'tenant[description]', with: "This good description"
+      fill_in 'tenant[name]', with: 'Chase Business'
+      fill_in 'tenant[description]', with: 'This good description'
       click_link_or_button 'Apply'
-      expect(page).to have_content("Chase Business")
-      click_link_or_button "Create new loan request"
-      expect(page).to have_content("Create New Loan Request")
+      expect(page).to have_content('Chase Business')
+      click_link_or_button 'Create new loan request'
+      expect(page).to have_content('Create New Loan Request')
 
-      fill_in 'loan_request[blurb]', with: "I need more money"
-      fill_in 'loan_request[description]', with: "I need lots of  money"
-      fill_in 'loan_request[borrowing_amount]', with: "5000"
-      fill_in 'loan_request[requested_by_date]', with: DateTime.new(2015, 01, 01)
-      fill_in 'loan_request[payments_begin_date]', with: DateTime.new(2015, 01, 28)
-      fill_in 'loan_request[payments_end_date]', with: DateTime.new(2015, 12, 28)
-      click_link_or_button "Submit"
-      expect(page).to have_content("Create New Loan Request")
-      expect(page).to have_content("error occurred")
+      fill_in 'loan_request[blurb]', with: 'I need more money'
+      fill_in 'loan_request[description]', with: 'I need lots of  money'
+      fill_in 'loan_request[borrowing_amount]', with: '5000'
+      fill_in 'loan_request[requested_by_date]', with: DateTime.now
+      fill_in 'loan_request[payments_begin_date]', with: DateTime.now.months_since(1)
+      fill_in 'loan_request[payments_end_date]', with: DateTime.now.months_since(10)
+      click_link_or_button 'Submit'
+      expect(page).to have_content('Create New Loan Request')
+      expect(page).to have_content('error occurred')
     end
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -13,11 +13,29 @@ RSpec.describe Category do
   #   end
   # end
 
-  describe "relationships" do
-    it "has many loan requests" do
-      category = Category.create(name: "name", description: "description")
-      loan_request = LoanRequest.create(user_id: 1, title: "title", blurb: "blurb", description: "description", borrowing_amount: 10, amount_funded: 0, requested_by_date: DateTime.new, payments_begin_date: DateTime.new, payments_end_date: DateTime.new, status: true, categories: [category])
-      loan_request1 = LoanRequest.create(user_id: 2, title: "title1", blurb: "blurb", description: "description1", borrowing_amount: 110, amount_funded: 10, requested_by_date: DateTime.new, payments_begin_date: DateTime.new, payments_end_date: DateTime.new, status: true, categories: [category])
+  describe 'relationships' do
+    it 'has many loan requests' do
+      category = Category.create(name: 'name', description: 'description')
+      loan_request = LoanRequest.create(user_id: 1, title: 'title',
+                                        blurb: 'blurb',
+                                        description: 'description',
+                                        borrowing_amount: 10,
+                                        amount_funded: 0,
+                                        requested_by_date: DateTime.now,
+                                        payments_begin_date: DateTime.now.months_since(1),
+                                        payments_end_date: DateTime.now.months_since(7),
+                                        status: true, categories: [category])
+
+      loan_request1 = LoanRequest.create(user_id: 2, title: 'title1',
+                                         blurb: 'blurb',
+                                         description: 'description1',
+                                         borrowing_amount: 110,
+                                         amount_funded: 10,
+                                         requested_by_date: DateTime.now,
+                                         payments_begin_date: DateTime.now.months_since(1),
+                                         payments_end_date: DateTime.now.months_since(7),
+                                         status: true, categories: [category])
+
       expect(category.loan_requests).to eq([loan_request1, loan_request])
     end
   end

--- a/spec/models/loan_request_spec.rb
+++ b/spec/models/loan_request_spec.rb
@@ -2,29 +2,25 @@ require 'rails_helper'
 
 RSpec.describe LoanRequest do
   let(:category) do
-    category = Category.create(name: 'name',
-                               description: 'description'
-                              )
+    Category.create(name: 'name', description: 'description')
   end
 
   let(:category1) do
-    category1 = Category.create(name: 'name',
-                                description: 'description'
-                               )
+    Category.create(name: 'name', description: 'description')
   end
 
   let(:loan_request) do
-    loan_request = LoanRequest.create(user_id: 1,
-                                      categories: [category, category1],
-                                      title: 'title',
-                                      description: 'description',
-                                      borrowing_amount: 10_000,
-                                      amount_funded: 0,
-                                      requested_by_date: DateTime.new,
-                                      payments_begin_date: DateTime.now,
-                                      payments_end_date: DateTime.now.months_since(5),
-                                      status: true
-                                     )
+    LoanRequest.create(user_id: 1,
+                       categories: [category, category1],
+                       title: 'title',
+                       blurb: 'blurb',
+                       description: 'description',
+                       borrowing_amount: 10_000,
+                       amount_funded: 0,
+                       requested_by_date: DateTime.now,
+                       payments_begin_date: DateTime.now.months_since(1),
+                       payments_end_date: DateTime.now.months_since(7),
+                       status: true)
   end
 
   describe 'relationships' do
@@ -33,13 +29,35 @@ RSpec.describe LoanRequest do
     end
   end
 
+  describe 'blurb' do
+    it 'must have a short description' do
+      loan_request.blurb = nil
+      expect(loan_request).to_not be_valid
+    end
+  end
+
   describe 'repayment terms' do
     it 'calculates the loan term in months' do
-      expect(loan_request.loan_term).to eq(5)
+      expect(loan_request.loan_term).to eq(6)
     end
 
     it 'calculates the monthly repayment rate' do
-      expect(loan_request.repayment_rate).to eq(2000)
+      expect(loan_request.repayment_rate).to eq(1666)
+    end
+
+    it 'the request date cannot be in the past' do
+      loan_request.requested_by_date = DateTime.now.months_ago(1)
+      expect(loan_request).to_not be_valid
+    end
+
+    it 'the payment start date is at least one month from the request' do
+      loan_request.payments_begin_date = DateTime.now.months_since(1)
+      expect(loan_request).to be_valid
+    end
+
+    it 'the payment end date is at least three months from the request' do
+      loan_request.payments_end_date = DateTime.now.months_since(5)
+      expect(loan_request).to be_valid
     end
   end
 end


### PR DESCRIPTION
Updated specs to use dynamically assigned dates, so that the specs are less brittle.

Please make a note the code example below and use in future specs:

```
requested_by_date: DateTime.now,
payments_begin_date: DateTime.now.months_since(1),
payments_end_date: DateTime.now.months_since(7),
```